### PR TITLE
only requires needed build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This builds the buildpack's source using GOOS=linux by default. You can supply a
 ## `buildpack.yml` Configurations
 
 ```yaml
-dotnet-build:                                                                                                                                                 
+dotnet-build:
   # this allows you to set the location of the web app inside of the app root
   # if not set it will default to the app root
   project-path: "src/asp_web_app"

--- a/detect.go
+++ b/detect.go
@@ -3,7 +3,6 @@ package dotnetpublish
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/paketo-buildpacks/packit"
 )
@@ -16,8 +15,6 @@ type BuildPlanMetadata struct {
 
 //go:generate faux --interface ProjectParser --output fakes/project_parser.go
 type ProjectParser interface {
-	ParseVersion(path string) (version string, err error)
-
 	ASPNetIsRequired(path string) (bool, error)
 	NodeIsRequired(path string) (bool, error)
 	NPMIsRequired(path string) (bool, error)
@@ -46,38 +43,18 @@ func Detect(parser ProjectParser, buildpackYMLParser BuildpackYMLParser) packit.
 		}
 
 		projectFilePath := matches[0]
-		runtimeVersion, err := parser.ParseVersion(projectFilePath)
-		if err != nil {
-			return packit.DetectResult{}, err
-		}
-
-		parts := strings.Split(runtimeVersion, ".")
-		if len(parts) < 2 {
-			return packit.DetectResult{}, fmt.Errorf("failed to parse runtime version %q: expected valid semver format", runtimeVersion)
-		}
-		sdkVersion := strings.Join([]string{parts[0], parts[1], "0"}, ".")
 
 		requirements := []packit.BuildPlanRequirement{
 			{
-				Name: "build",
+				Name: "dotnet-sdk",
 				Metadata: BuildPlanMetadata{
 					Build: true,
 				},
 			},
 			{
-				Name: "dotnet-sdk",
-				Metadata: BuildPlanMetadata{
-					Version: sdkVersion,
-					Build:   true,
-					Launch:  true,
-				},
-			},
-			{
 				Name: "dotnet-runtime",
 				Metadata: BuildPlanMetadata{
-					Version: runtimeVersion,
-					Build:   true,
-					Launch:  true,
+					Build: true,
 				},
 			},
 			{
@@ -97,9 +74,7 @@ func Detect(parser ProjectParser, buildpackYMLParser BuildpackYMLParser) packit.
 			requirements = append(requirements, packit.BuildPlanRequirement{
 				Name: "dotnet-aspnetcore",
 				Metadata: BuildPlanMetadata{
-					Version: runtimeVersion,
-					Build:   true,
-					Launch:  true,
+					Build: true,
 				},
 			})
 		}
@@ -113,8 +88,7 @@ func Detect(parser ProjectParser, buildpackYMLParser BuildpackYMLParser) packit.
 			requirements = append(requirements, packit.BuildPlanRequirement{
 				Name: "node",
 				Metadata: BuildPlanMetadata{
-					Build:  true,
-					Launch: true,
+					Build: true,
 				},
 			})
 		}
@@ -128,8 +102,7 @@ func Detect(parser ProjectParser, buildpackYMLParser BuildpackYMLParser) packit.
 			requirements = append(requirements, packit.BuildPlanRequirement{
 				Name: "npm",
 				Metadata: BuildPlanMetadata{
-					Build:  true,
-					Launch: true,
+					Build: true,
 				},
 			})
 		}

--- a/detect_test.go
+++ b/detect_test.go
@@ -35,7 +35,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 		projectParser = &fakes.ProjectParser{}
 		buildpackYMLParser = &fakes.BuildpackYMLParser{}
-		projectParser.ParseVersionCall.Returns.Version = "1.2.3"
 
 		detect = dotnetpublish.Detect(projectParser, buildpackYMLParser)
 	})
@@ -56,25 +55,15 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				},
 				Requires: []packit.BuildPlanRequirement{
 					{
-						Name: "build",
+						Name: "dotnet-sdk",
 						Metadata: dotnetpublish.BuildPlanMetadata{
 							Build: true,
 						},
 					},
 					{
-						Name: "dotnet-sdk",
-						Metadata: dotnetpublish.BuildPlanMetadata{
-							Version: "1.2.0",
-							Build:   true,
-							Launch:  true,
-						},
-					},
-					{
 						Name: "dotnet-runtime",
 						Metadata: dotnetpublish.BuildPlanMetadata{
-							Version: "1.2.3",
-							Build:   true,
-							Launch:  true,
+							Build: true,
 						},
 					},
 					{
@@ -105,25 +94,15 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					},
 					Requires: []packit.BuildPlanRequirement{
 						{
-							Name: "build",
+							Name: "dotnet-sdk",
 							Metadata: dotnetpublish.BuildPlanMetadata{
 								Build: true,
 							},
 						},
 						{
-							Name: "dotnet-sdk",
-							Metadata: dotnetpublish.BuildPlanMetadata{
-								Version: "1.2.0",
-								Build:   true,
-								Launch:  true,
-							},
-						},
-						{
 							Name: "dotnet-runtime",
 							Metadata: dotnetpublish.BuildPlanMetadata{
-								Version: "1.2.3",
-								Build:   true,
-								Launch:  true,
+								Build: true,
 							},
 						},
 						{
@@ -135,9 +114,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						{
 							Name: "dotnet-aspnetcore",
 							Metadata: dotnetpublish.BuildPlanMetadata{
-								Version: "1.2.3",
-								Build:   true,
-								Launch:  true,
+								Build: true,
 							},
 						},
 					},
@@ -163,25 +140,15 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					},
 					Requires: []packit.BuildPlanRequirement{
 						{
-							Name: "build",
+							Name: "dotnet-sdk",
 							Metadata: dotnetpublish.BuildPlanMetadata{
 								Build: true,
 							},
 						},
 						{
-							Name: "dotnet-sdk",
-							Metadata: dotnetpublish.BuildPlanMetadata{
-								Version: "1.2.0",
-								Build:   true,
-								Launch:  true,
-							},
-						},
-						{
 							Name: "dotnet-runtime",
 							Metadata: dotnetpublish.BuildPlanMetadata{
-								Version: "1.2.3",
-								Build:   true,
-								Launch:  true,
+								Build: true,
 							},
 						},
 						{
@@ -193,8 +160,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						{
 							Name: "node",
 							Metadata: dotnetpublish.BuildPlanMetadata{
-								Build:  true,
-								Launch: true,
+								Build: true,
 							},
 						},
 					},
@@ -221,25 +187,15 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					},
 					Requires: []packit.BuildPlanRequirement{
 						{
-							Name: "build",
+							Name: "dotnet-sdk",
 							Metadata: dotnetpublish.BuildPlanMetadata{
 								Build: true,
 							},
 						},
 						{
-							Name: "dotnet-sdk",
-							Metadata: dotnetpublish.BuildPlanMetadata{
-								Version: "1.2.0",
-								Build:   true,
-								Launch:  true,
-							},
-						},
-						{
 							Name: "dotnet-runtime",
 							Metadata: dotnetpublish.BuildPlanMetadata{
-								Version: "1.2.3",
-								Build:   true,
-								Launch:  true,
+								Build: true,
 							},
 						},
 						{
@@ -251,15 +207,13 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						{
 							Name: "node",
 							Metadata: dotnetpublish.BuildPlanMetadata{
-								Build:  true,
-								Launch: true,
+								Build: true,
 							},
 						},
 						{
 							Name: "npm",
 							Metadata: dotnetpublish.BuildPlanMetadata{
-								Build:  true,
-								Launch: true,
+								Build: true,
 							},
 						},
 					},
@@ -295,25 +249,15 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					},
 					Requires: []packit.BuildPlanRequirement{
 						{
-							Name: "build",
+							Name: "dotnet-sdk",
 							Metadata: dotnetpublish.BuildPlanMetadata{
 								Build: true,
 							},
 						},
 						{
-							Name: "dotnet-sdk",
-							Metadata: dotnetpublish.BuildPlanMetadata{
-								Version: "1.2.0",
-								Build:   true,
-								Launch:  true,
-							},
-						},
-						{
 							Name: "dotnet-runtime",
 							Metadata: dotnetpublish.BuildPlanMetadata{
-								Version: "1.2.3",
-								Build:   true,
-								Launch:  true,
+								Build: true,
 							},
 						},
 						{
@@ -352,28 +296,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					WorkingDir: workingDir,
 				})
 				Expect(err).To(MatchError(packit.Fail.WithMessage("no project file found")))
-			})
-		})
-
-		context("when .?proj file cannot be parsed", func() {
-			it.Before(func() {
-				projectParser.ParseVersionCall.Returns.Err = errors.New("failed to parse project file version")
-			})
-
-			it("returns an error", func() {
-				_, err := detect(packit.DetectContext{WorkingDir: workingDir})
-				Expect(err).To(MatchError("failed to parse project file version"))
-			})
-		})
-
-		context("when the runtime version is malformed", func() {
-			it.Before(func() {
-				projectParser.ParseVersionCall.Returns.Version = "some-version"
-			})
-
-			it("returns an error", func() {
-				_, err := detect(packit.DetectContext{WorkingDir: workingDir})
-				Expect(err).To(MatchError("failed to parse runtime version \"some-version\": expected valid semver format"))
 			})
 		})
 

--- a/fakes/project_parser.go
+++ b/fakes/project_parser.go
@@ -39,18 +39,6 @@ type ProjectParser struct {
 		}
 		Stub func(string) (bool, error)
 	}
-	ParseVersionCall struct {
-		sync.Mutex
-		CallCount int
-		Receives  struct {
-			Path string
-		}
-		Returns struct {
-			Version string
-			Err     error
-		}
-		Stub func(string) (string, error)
-	}
 }
 
 func (f *ProjectParser) ASPNetIsRequired(param1 string) (bool, error) {
@@ -82,14 +70,4 @@ func (f *ProjectParser) NodeIsRequired(param1 string) (bool, error) {
 		return f.NodeIsRequiredCall.Stub(param1)
 	}
 	return f.NodeIsRequiredCall.Returns.Bool, f.NodeIsRequiredCall.Returns.Error
-}
-func (f *ProjectParser) ParseVersion(param1 string) (string, error) {
-	f.ParseVersionCall.Lock()
-	defer f.ParseVersionCall.Unlock()
-	f.ParseVersionCall.CallCount++
-	f.ParseVersionCall.Receives.Path = param1
-	if f.ParseVersionCall.Stub != nil {
-		return f.ParseVersionCall.Stub(param1)
-	}
-	return f.ParseVersionCall.Returns.Version, f.ParseVersionCall.Returns.Err
 }

--- a/run/main.go
+++ b/run/main.go
@@ -16,7 +16,7 @@ func main() {
 
 	packit.Run(
 		dotnetpublish.Detect(
-			dotnetpublish.NewDotnetProjectFileParser(),
+			dotnetpublish.NewProjectFileParser(),
 			bpYMLParser,
 		),
 		dotnetpublish.Build(


### PR DESCRIPTION
Co-authored-by: Arjun Sreedharan <asreedharan@vmware.com>

Thanks for contributing. To speed up the process of reviewing your pull request
please provide us with:

* A short explanation of the proposed change:

Only require needed dependencies on `build`, and don't specify the versions of those dependencies, as we are pushing that responsibility to the `dotnet-execute` buildpack.

We did not rename the provided dependency to `dotnet-application`, as it causes the integration tests to fail until we publish a corresponding change in `dotnet-execute`, so we thought it might be better to make that change on its own.

A more complete description of this change can be found in the corresponding issue: [ #85 ]

* An explanation of the use cases your change enables:

This should support all current use cases.

Please confirm the following:
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
