### PR TITLE
Detect: Provide dotnet-application OR build

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -113,6 +113,14 @@ func Detect(parser ProjectParser, buildpackYMLParser BuildpackYMLParser) packit.
 					{Name: "build"},
 				},
 				Requires: requirements,
+				Or: []packit.BuildPlan{
+					{
+						Provides: []packit.BuildPlanProvision{
+							{Name: "dotnet-application"},
+						},
+						Requires: requirements,
+					},
+				},
 			},
 		}, nil
 	}

--- a/detect_test.go
+++ b/detect_test.go
@@ -73,6 +73,33 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						},
 					},
 				},
+				Or: []packit.BuildPlan{
+					{
+						Provides: []packit.BuildPlanProvision{
+							{Name: "dotnet-application"},
+						},
+						Requires: []packit.BuildPlanRequirement{
+							{
+								Name: "dotnet-sdk",
+								Metadata: dotnetpublish.BuildPlanMetadata{
+									Build: true,
+								},
+							},
+							{
+								Name: "dotnet-runtime",
+								Metadata: dotnetpublish.BuildPlanMetadata{
+									Build: true,
+								},
+							},
+							{
+								Name: "icu",
+								Metadata: dotnetpublish.BuildPlanMetadata{
+									Build: true,
+								},
+							},
+						},
+					},
+				},
 			},
 		}))
 	})
@@ -115,6 +142,39 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							Name: "dotnet-aspnetcore",
 							Metadata: dotnetpublish.BuildPlanMetadata{
 								Build: true,
+							},
+						},
+					},
+					Or: []packit.BuildPlan{
+						{
+							Provides: []packit.BuildPlanProvision{
+								{Name: "dotnet-application"},
+							},
+							Requires: []packit.BuildPlanRequirement{
+								{
+									Name: "dotnet-sdk",
+									Metadata: dotnetpublish.BuildPlanMetadata{
+										Build: true,
+									},
+								},
+								{
+									Name: "dotnet-runtime",
+									Metadata: dotnetpublish.BuildPlanMetadata{
+										Build: true,
+									},
+								},
+								{
+									Name: "icu",
+									Metadata: dotnetpublish.BuildPlanMetadata{
+										Build: true,
+									},
+								},
+								{
+									Name: "dotnet-aspnetcore",
+									Metadata: dotnetpublish.BuildPlanMetadata{
+										Build: true,
+									},
+								},
 							},
 						},
 					},
@@ -161,6 +221,39 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							Name: "node",
 							Metadata: dotnetpublish.BuildPlanMetadata{
 								Build: true,
+							},
+						},
+					},
+					Or: []packit.BuildPlan{
+						{
+							Provides: []packit.BuildPlanProvision{
+								{Name: "dotnet-application"},
+							},
+							Requires: []packit.BuildPlanRequirement{
+								{
+									Name: "dotnet-sdk",
+									Metadata: dotnetpublish.BuildPlanMetadata{
+										Build: true,
+									},
+								},
+								{
+									Name: "dotnet-runtime",
+									Metadata: dotnetpublish.BuildPlanMetadata{
+										Build: true,
+									},
+								},
+								{
+									Name: "icu",
+									Metadata: dotnetpublish.BuildPlanMetadata{
+										Build: true,
+									},
+								},
+								{
+									Name: "node",
+									Metadata: dotnetpublish.BuildPlanMetadata{
+										Build: true,
+									},
+								},
 							},
 						},
 					},
@@ -217,6 +310,45 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							},
 						},
 					},
+					Or: []packit.BuildPlan{
+						{
+							Provides: []packit.BuildPlanProvision{
+								{Name: "dotnet-application"},
+							},
+							Requires: []packit.BuildPlanRequirement{
+								{
+									Name: "dotnet-sdk",
+									Metadata: dotnetpublish.BuildPlanMetadata{
+										Build: true,
+									},
+								},
+								{
+									Name: "dotnet-runtime",
+									Metadata: dotnetpublish.BuildPlanMetadata{
+										Build: true,
+									},
+								},
+								{
+									Name: "icu",
+									Metadata: dotnetpublish.BuildPlanMetadata{
+										Build: true,
+									},
+								},
+								{
+									Name: "node",
+									Metadata: dotnetpublish.BuildPlanMetadata{
+										Build: true,
+									},
+								},
+								{
+									Name: "npm",
+									Metadata: dotnetpublish.BuildPlanMetadata{
+										Build: true,
+									},
+								},
+							},
+						},
+					},
 				},
 			}))
 		})
@@ -264,6 +396,33 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							Name: "icu",
 							Metadata: dotnetpublish.BuildPlanMetadata{
 								Build: true,
+							},
+						},
+					},
+					Or: []packit.BuildPlan{
+						{
+							Provides: []packit.BuildPlanProvision{
+								{Name: "dotnet-application"},
+							},
+							Requires: []packit.BuildPlanRequirement{
+								{
+									Name: "dotnet-sdk",
+									Metadata: dotnetpublish.BuildPlanMetadata{
+										Build: true,
+									},
+								},
+								{
+									Name: "dotnet-runtime",
+									Metadata: dotnetpublish.BuildPlanMetadata{
+										Build: true,
+									},
+								},
+								{
+									Name: "icu",
+									Metadata: dotnetpublish.BuildPlanMetadata{
+										Build: true,
+									},
+								},
 							},
 						},
 					},


### PR DESCRIPTION
This helps us move dotnet-execute to move to the new
API per RFC 0001

Signed-off-by: Arjun Sreedharan <asreedharan@vmware.com>
Co-authored-by: Arjun Sreedharan <asreedharan@vmware.com>

Thanks for contributing. To speed up the process of reviewing your pull request
please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change enables:

Please confirm the following:
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
