### PR TITLE
write the PUBLISH_OUTPUT_LOCATION variable to build and launch

### DIFF
--- a/build.go
+++ b/build.go
@@ -38,9 +38,9 @@ func Build(
 		publishOutputLayer.Launch = true
 		publishOutputLayer.Build = true
 
-		publishOutputLayer.BuildEnv.Override("PUBLISH_OUTPUT_LOCATION", publishOutputLayer.Path)
+		publishOutputLayer.SharedEnv.Override("PUBLISH_OUTPUT_LOCATION", publishOutputLayer.Path)
 		logger.Process("Configuring environment")
-		logger.Subprocess("%s", scribe.NewFormattedMapFromEnvironment(publishOutputLayer.BuildEnv))
+		logger.Subprocess("%s", scribe.NewFormattedMapFromEnvironment(publishOutputLayer.SharedEnv))
 		logger.Break()
 
 		rootDir := filepath.Join(context.WorkingDir, ".dotnet-root")

--- a/build_test.go
+++ b/build_test.go
@@ -86,8 +86,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				{
 					Name:      "publish-output",
 					Path:      filepath.Join(layersDir, "publish-output"),
-					SharedEnv: packit.Environment{},
-					BuildEnv:  packit.Environment{"PUBLISH_OUTPUT_LOCATION.override": filepath.Join(layersDir, "publish-output")},
+					SharedEnv: packit.Environment{"PUBLISH_OUTPUT_LOCATION.override": filepath.Join(layersDir, "publish-output")},
+					BuildEnv:  packit.Environment{},
 					LaunchEnv: packit.Environment{},
 					Build:     true,
 					Launch:    true,


### PR DESCRIPTION
Thanks for contributing. To speed up the process of reviewing your pull request
please provide us with:

* A short explanation of the proposed change:

write the PUBLISH_OUTPUT_LOCATION variable to build and launch

* An explanation of the use cases your change enables:

needed in launch env so the procfile buildpack can find apps
[https://github.com/paketo-buildpacks/dotnet-core/issues/6]

Please confirm the following:
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
