### PR TITLE
simplify symlinking interface

### DIFF
--- a/build.go
+++ b/build.go
@@ -86,7 +86,7 @@ func Build(
 		}
 
 		if globalNugetPath != "" {
-			err = setupBindingSymlink(symlinker, globalNugetPath, filepath.Join(homeDir, ".nuget", "NuGet"), "NuGet.Config")
+			err = symlinker.Link(globalNugetPath, filepath.Join(homeDir, ".nuget", "NuGet", "NuGet.Config"))
 			if err != nil {
 				return packit.BuildResult{}, err
 			}
@@ -147,17 +147,4 @@ func getBinding(typ, provider, bindingsRoot, entry string, bindingResolver Bindi
 		return filepath.Join(bindings[0].Path, entry), nil
 	}
 	return "", nil
-}
-
-func setupBindingSymlink(symlinker SymlinkManager, originalPath, newPath, filename string) error {
-	err := os.MkdirAll(newPath, os.ModePerm)
-	if err != nil {
-		return fmt.Errorf("failed to make directory for %s: %w", filename, err)
-	}
-
-	err = symlinker.Link(originalPath, filepath.Join(newPath, filename))
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/build_test.go
+++ b/build_test.go
@@ -323,36 +323,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 
-		context("when the $HOME/.nuget/NuGet path cannot be created for the nuget.config", func() {
-			it.Before(func() {
-				bindingResolver.ResolveCall.Returns.BindingSlice = []servicebindings.Binding{
-					servicebindings.Binding{
-						Name: "some-binding",
-						Path: "some-binding-path",
-						Type: "nugetconfig",
-						Entries: map[string]*servicebindings.Entry{
-							"nuget.config": servicebindings.NewEntry("some-binding-path"),
-						},
-					},
-				}
-				Expect(os.Mkdir(filepath.Join(homeDir, ".nuget"), 0000)).To(Succeed())
-			})
-
-			it.After(func() {
-				Expect(os.RemoveAll(filepath.Join(homeDir, ".nuget"))).To(Succeed())
-			})
-
-			it("returns an error", func() {
-				_, err := build(packit.BuildContext{
-					WorkingDir: workingDir,
-					BuildpackInfo: packit.BuildpackInfo{
-						Version: "0.0.1",
-					},
-				})
-				Expect(err).To(MatchError(ContainSubstring("failed to make directory for NuGet.Config")))
-			})
-		})
-
 		context("when symlinking the nuget.config path to the binding path fails", func() {
 			it.Before(func() {
 				bindingResolver.ResolveCall.Returns.BindingSlice = []servicebindings.Binding{

--- a/symlinker.go
+++ b/symlinker.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 type Symlinker struct{}
@@ -13,6 +14,10 @@ func NewSymlinker() Symlinker {
 }
 
 func (s Symlinker) Link(oldname, newname string) error {
+	err := os.MkdirAll(filepath.Dir(newname), os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("failed to make directory for symlink: %w", err)
+	}
 	return os.Symlink(oldname, newname)
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
@sophiewigmore I saw a way to streamline the symlinking interface a bit in this buildpack. I allowed the symlinker's functionality to diverge a bit from the one in the NodeJS buildpacks so it's more convenient for this use-case. This way, filesystem manipulation for symlinks is contained entirely in the Symlinker abstraction.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
