### PR TITLE
Divide build output into layers to optimize layer cache hits

### DIFF
--- a/fakes/slicer.go
+++ b/fakes/slicer.go
@@ -1,0 +1,35 @@
+package fakes
+
+import (
+	"sync"
+
+	packit "github.com/paketo-buildpacks/packit/v2"
+)
+
+type Slicer struct {
+	SliceCall struct {
+		mutex     sync.Mutex
+		CallCount int
+		Receives  struct {
+			AssetsFile string
+		}
+		Returns struct {
+			Pkgs      packit.Slice
+			EarlyPkgs packit.Slice
+			Projects  packit.Slice
+			Err       error
+		}
+		Stub func(string) (packit.Slice, packit.Slice, packit.Slice, error)
+	}
+}
+
+func (f *Slicer) Slice(param1 string) (packit.Slice, packit.Slice, packit.Slice, error) {
+	f.SliceCall.mutex.Lock()
+	defer f.SliceCall.mutex.Unlock()
+	f.SliceCall.CallCount++
+	f.SliceCall.Receives.AssetsFile = param1
+	if f.SliceCall.Stub != nil {
+		return f.SliceCall.Stub(param1)
+	}
+	return f.SliceCall.Returns.Pkgs, f.SliceCall.Returns.EarlyPkgs, f.SliceCall.Returns.Projects, f.SliceCall.Returns.Err
+}

--- a/init_test.go
+++ b/init_test.go
@@ -17,5 +17,6 @@ func TestUnitDotnetPublish(t *testing.T) {
 	suite("DotnetSourceRemover", testDotnetSourceRemover)
 	suite("ProjectFileParser", testProjectFileParser)
 	suite("Symlinker", testSymlinker)
+	suite("OutputSlicer", testOutputSlicer)
 	suite.Run(t)
 }

--- a/integration/buildpack_yml_test.go
+++ b/integration/buildpack_yml_test.go
@@ -81,6 +81,8 @@ dotnet-build:
 			Expect(logs).To(ContainLines(
 				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
 				"",
+				"  Dividing build output into layers to optimize cache reuse",
+				"",
 				"  Removing source code",
 				"",
 			))

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sclevine/spec/report"
 
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 )
 
 var (
@@ -132,6 +133,7 @@ func TestIntegration(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 
 	SetDefaultEventuallyTimeout(30 * time.Second)
+	format.MaxLength = 0
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("BuildpackYML", testBuildpackYML)
@@ -144,5 +146,6 @@ func TestIntegration(t *testing.T) {
 	suite("SourceRemoval", testSourceRemoval)
 	suite("VisualBasic", testVisualBasic)
 	suite("Nuget", testNugetConfig)
+	suite("OutputSlicing", testOutputSlicing)
 	suite.Run(t)
 }

--- a/integration/match_dir_and_app_name_test.go
+++ b/integration/match_dir_and_app_name_test.go
@@ -73,6 +73,8 @@ func testMatchDirAndAppName(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
 				"",
+				"  Dividing build output into layers to optimize cache reuse",
+				"",
 				"  Removing source code",
 				"",
 			))

--- a/integration/output_slicing_test.go
+++ b/integration/output_slicing_test.go
@@ -83,6 +83,14 @@ func testOutputSlicing(t *testing.T, context spec.G, it spec.S) {
 
 				Expect(os.WriteFile(filepath.Join(source, "Startup.cs"), contents, os.ModePerm)).To(Succeed())
 
+				modifiedFile, err := os.Open(filepath.Join(source, "Startup.cs"))
+				Expect(err).NotTo(HaveOccurred())
+				defer modifiedFile.Close()
+
+				contents, err = io.ReadAll(file)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(contents).To(ContainSubstring("My Cool V1 API"), string(contents))
+
 				image, logs, err = build.Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
 				images[image.ID] = ""

--- a/integration/output_slicing_test.go
+++ b/integration/output_slicing_test.go
@@ -74,7 +74,6 @@ func testOutputSlicing(t *testing.T, context spec.G, it spec.S) {
 
 				file, err := os.Open(filepath.Join(source, "Startup.cs"))
 				Expect(err).NotTo(HaveOccurred())
-				defer file.Close()
 
 				contents, err := io.ReadAll(file)
 				Expect(err).NotTo(HaveOccurred())
@@ -82,14 +81,15 @@ func testOutputSlicing(t *testing.T, context spec.G, it spec.S) {
 				contents = bytes.Replace(contents, []byte("My API V1"), []byte("My Cool V1 API"), 1)
 
 				Expect(os.WriteFile(filepath.Join(source, "Startup.cs"), contents, os.ModePerm)).To(Succeed())
+				file.Close()
 
-				modifiedFile, err := os.Open(filepath.Join(source, "Startup.cs"))
+				modified, err := os.Open(filepath.Join(source, "Startup.cs"))
 				Expect(err).NotTo(HaveOccurred())
-				defer modifiedFile.Close()
 
-				contents, err = io.ReadAll(file)
+				contents, err = io.ReadAll(modified)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(contents).To(ContainSubstring("My Cool V1 API"), string(contents))
+				Expect(string(contents)).To(ContainSubstring("My Cool V1 API"))
+				modified.Close()
 
 				image, logs, err = build.Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())

--- a/integration/output_slicing_test.go
+++ b/integration/output_slicing_test.go
@@ -1,0 +1,96 @@
+package integration_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
+)
+
+func testOutputSlicing(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+		pack   occam.Pack
+		docker occam.Docker
+	)
+
+	it.Before(func() {
+		pack = occam.NewPack()
+		docker = occam.NewDocker()
+	})
+
+	context("when rebuilding an app", func() {
+		var (
+			image  occam.Image
+			images map[string]string
+			name   string
+			source string
+		)
+
+		it.Before(func() {
+			var err error
+			name, err = occam.RandomName()
+			Expect(err).NotTo(HaveOccurred())
+
+			images = make(map[string]string)
+		})
+
+		it.After(func() {
+			for id := range images {
+				Expect(docker.Image.Remove.Execute(id)).To(Succeed())
+			}
+			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
+		})
+
+		context("when app source changes, NuGet packages are unchanged", func() {
+			it("reuses package layers, adds a new app layer", func() {
+				var err error
+				source, err := occam.Source(filepath.Join("testdata", "source-3.1-aspnet-with-public-nuget"))
+				Expect(err).NotTo(HaveOccurred())
+
+				build := pack.WithNoColor().Build.
+					WithBuildpacks(
+						icuBuildpack,
+						dotnetCoreRuntimeBuildpack,
+						dotnetCoreAspNetBuildpack,
+						dotnetCoreSDKBuildpack,
+						buildpack,
+						dotnetExecuteBuildpack,
+					)
+
+				var logs fmt.Stringer
+				image, logs, err = build.Execute(name, source)
+				Expect(err).NotTo(HaveOccurred(), logs.String())
+				images[image.ID] = ""
+
+				file, err := os.Open(filepath.Join(source, "Startup.cs"))
+				Expect(err).NotTo(HaveOccurred())
+				defer file.Close()
+
+				contents, err := io.ReadAll(file)
+				Expect(err).NotTo(HaveOccurred())
+
+				contents = bytes.Replace(contents, []byte("My API V1"), []byte("My Cool V1 API"), 1)
+
+				Expect(os.WriteFile(filepath.Join(source, "Startup.cs"), contents, os.ModePerm)).To(Succeed())
+
+				image, logs, err = build.Execute(name, source)
+				Expect(err).NotTo(HaveOccurred(), logs.String())
+				images[image.ID] = ""
+				Expect(logs).To(ContainLines(
+					"Reusing 2/3 app layer(s)",
+					"Adding 1/3 app layer(s)",
+				), logs.String())
+			})
+		})
+	})
+}

--- a/integration/source_removal_test.go
+++ b/integration/source_removal_test.go
@@ -74,6 +74,8 @@ func testSourceRemoval(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
 				"",
+				"  Dividing build output into layers to optimize cache reuse",
+				"",
 				"  Removing source code",
 				"",
 			))

--- a/integration/visual_basic_test.go
+++ b/integration/visual_basic_test.go
@@ -72,6 +72,8 @@ func testVisualBasic(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
 				"",
+				"  Dividing build output into layers to optimize cache reuse",
+				"",
 				"  Removing source code",
 				"",
 			))

--- a/internal/init_test.go
+++ b/internal/init_test.go
@@ -1,0 +1,17 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+)
+
+func TestUnitInternal(t *testing.T) {
+	suite := spec.New("internal", spec.Report(report.Terminal{}))
+	suite("Targets", testTargets)
+	suite("RuntimeTargets", testRuntimeTargets)
+	suite("Runtime", testRuntime)
+	suite("Dependencies", testDependencies)
+	suite.Run(t)
+}

--- a/internal/project_assets_json.go
+++ b/internal/project_assets_json.go
@@ -1,0 +1,98 @@
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type ProjectAssetsJSON struct {
+	Targets Targets
+}
+
+type Targets []Target
+
+type Target struct {
+	Name         string
+	Dependencies Dependencies
+}
+
+type Dependencies []ProjectDependency
+
+type ProjectDependency struct {
+	Name           string
+	Type           string         `json:"type"`
+	Runtime        Runtime        `json:"runtime"`
+	RuntimeTargets RuntimeTargets `json:"runtimeTargets"`
+}
+
+type Runtime string
+
+type RuntimeTargets []RuntimeTarget
+
+type RuntimeTarget struct {
+	FileName          string
+	AssetType         string
+	RuntimeIdentifier string
+}
+
+func (ts *Targets) UnmarshalJSON(data []byte) error {
+	var result []Target
+	var v map[string]Dependencies
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	for name, deps := range v {
+		result = append(result, Target{
+			Name:         name,
+			Dependencies: deps,
+		})
+	}
+	*ts = Targets(result)
+	return nil
+}
+
+func (ds *Dependencies) UnmarshalJSON(data []byte) error {
+	var result []ProjectDependency
+	var v map[string]ProjectDependency
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	for name, dep := range v {
+		dep.Name = name
+		result = append(result, dep)
+	}
+	*ds = Dependencies(result)
+	return nil
+}
+
+func (r *Runtime) UnmarshalJSON(data []byte) error {
+
+	var v map[string]interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	if len(v) != 1 {
+		return fmt.Errorf("dependency runtime file malformed")
+	}
+	for key := range v {
+		*r = Runtime(key)
+	}
+	return nil
+}
+
+func (ts *RuntimeTargets) UnmarshalJSON(data []byte) error {
+	result := []RuntimeTarget{}
+	var v map[string]map[string]interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	for key := range v {
+		result = append(result, RuntimeTarget{
+			FileName:          key,
+			AssetType:         v[key]["assetType"].(string),
+			RuntimeIdentifier: v[key]["rid"].(string),
+		})
+	}
+	*ts = RuntimeTargets(result)
+	return nil
+}

--- a/internal/project_assets_json_test.go
+++ b/internal/project_assets_json_test.go
@@ -1,0 +1,302 @@
+package internal_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/dotnet-publish/internal"
+	"github.com/sclevine/spec"
+)
+
+func testTargets(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect  = NewWithT(t).Expect
+		targets internal.Targets
+	)
+	var input []byte = []byte(`{
+    ".NETCoreApp,Version=v3.1": {
+      "Microsoft.AspNetCore.Diagnostics.HealthChecks/2.2.0-rc1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
+          "Microsoft.Net.Http.Headers": "2.2.0"
+        },
+        "compile": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Diagnostics.HealthChecks.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Diagnostics.HealthChecks.dll": {}
+        }
+      }
+    },
+    ".NETCoreApp,Version=v6.0": {
+      "Consul/0.7.2.6": {
+        "type": "package",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "System.Threading.Thread": "4.0.0"
+        },
+        "compile": {
+          "lib/netstandard1.3/Consul.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/Consul.dll": {}
+        }
+      }
+    }
+  }
+`)
+	var badInput []byte = []byte(`{
+    ".NETCoreApp,Version=v3.1": {
+      "Consul/0.7.2.6": {
+        "type": "package",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "System.Threading.Thread": "4.0.0"
+        },
+        "compile": {
+          "lib/netstandard1.3/Consul.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/Consul.dll": {}
+        }
+      },
+      "Microsoft.AspNetCore.Diagnostics.HealthChecks/2.2.0-rc1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
+          "Microsoft.Net.Http.Headers": "2.2.0"
+        },
+        "compile": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Diagnostics.HealthChecks.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Diagnostics.HealthChecks.dll": {}
+        }
+      }
+    },
+    ".NETCoreApp,Version=v6.0": {
+			"some-garbage" : true
+    }
+  }
+`)
+
+	context("UnmarshalJSON", func() {
+		it("correctly unmarshals JSON", func() {
+
+			err := json.Unmarshal(input, &targets)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(targets)).To(Equal(2))
+			// Must use ContainElement since maps are non-ordered; array ends up different after each unmarshalling
+			Expect(targets).To(ContainElement(internal.Target{
+				Name: ".NETCoreApp,Version=v3.1",
+				Dependencies: internal.Dependencies([]internal.ProjectDependency{
+					{
+						Name:    "Microsoft.AspNetCore.Diagnostics.HealthChecks/2.2.0-rc1",
+						Type:    "package",
+						Runtime: "lib/netstandard2.0/Microsoft.AspNetCore.Diagnostics.HealthChecks.dll",
+					},
+				}),
+			}))
+			Expect(targets).To(ContainElement(internal.Target{
+				Name: ".NETCoreApp,Version=v6.0",
+				Dependencies: internal.Dependencies([]internal.ProjectDependency{
+					{
+						Name:    "Consul/0.7.2.6",
+						Type:    "package",
+						Runtime: "lib/netstandard1.3/Consul.dll",
+					},
+				}),
+			}))
+		})
+		context("failure cases", func() {
+			context("when a target has an invalid dependency list structure", func() {
+				it("returns an error", func() {
+
+					err := json.Unmarshal(badInput, &targets)
+					Expect(err).To(MatchError(ContainSubstring("cannot unmarshal bool into Go value of type internal.ProjectDependency")), err.Error())
+				})
+			})
+		})
+	})
+}
+func testDependencies(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+		deps   internal.Dependencies
+	)
+	var input []byte = []byte(`{
+      "Consul/0.7.2.6": {
+        "type": "package",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "System.Threading.Thread": "4.0.0"
+        },
+        "compile": {
+          "lib/netstandard1.3/Consul.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/Consul.dll": {}
+        }
+      },
+      "Microsoft.Win32.Registry/4.6.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Security.AccessControl": "4.6.0",
+          "System.Security.Principal.Windows": "4.6.0"
+        },
+        "compile": {
+          "ref/netstandard2.0/_._": {}
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Win32.Registry.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/unix/lib/netstandard2.0/Microsoft.Win32.Registry.dll": {
+            "assetType": "runtime",
+            "rid": "unix"
+          }
+        }
+      }
+}`)
+	var badInput []byte = []byte(`{
+      "Consul/0.7.2.6": {
+        "type": "package",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "System.Threading.Thread": "4.0.0"
+        },
+        "compile": {
+          "lib/netstandard1.3/Consul.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard1.3/Consul.dll": {}
+        }
+      },
+			"some-garbage" : true
+}`)
+
+	context("UnmarshalJSON", func() {
+		it("correctly unmarshals JSON", func() {
+
+			err := json.Unmarshal(input, &deps)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(deps)).To(Equal(2))
+			Expect(deps).To(ContainElement(internal.ProjectDependency{
+				Name:    "Consul/0.7.2.6",
+				Type:    "package",
+				Runtime: "lib/netstandard1.3/Consul.dll",
+			}))
+			Expect(deps).To(ContainElement(internal.ProjectDependency{
+				Name:    "Microsoft.Win32.Registry/4.6.0",
+				Type:    "package",
+				Runtime: "lib/netstandard2.0/Microsoft.Win32.Registry.dll",
+				RuntimeTargets: internal.RuntimeTargets([]internal.RuntimeTarget{
+					{
+						FileName:          "runtimes/unix/lib/netstandard2.0/Microsoft.Win32.Registry.dll",
+						AssetType:         "runtime",
+						RuntimeIdentifier: "unix",
+					},
+				}),
+			}))
+		})
+
+		context("failure cases", func() {
+			context("when a target has an invalid dependency list structure", func() {
+				it("returns an error", func() {
+
+					err := json.Unmarshal(badInput, &deps)
+					Expect(err).To(MatchError(ContainSubstring("cannot unmarshal bool into Go value of type internal.ProjectDependency")), err.Error())
+				})
+			})
+		})
+	})
+}
+
+func testRuntimeTargets(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+		rts    internal.RuntimeTargets
+	)
+	var input []byte = []byte(`{
+          "runtimes/unix/lib/netstandard2.0/Microsoft.Win32.Registry.dll": {
+            "assetType": "runtime",
+            "rid": "unix"
+          },
+          "runtimes/win/lib/netstandard2.0/Microsoft.Win32.Registry.dll": {
+            "assetType": "runtime",
+            "rid": "win"
+          }
+        }`)
+	var badInput []byte = []byte(`{
+          "runtimes/unix/lib/netstandard2.0/Microsoft.Win32.Registry.dll": {
+            "assetType": "runtime",
+            "rid": "unix"
+          },
+          "some-garbage": true
+        }`)
+
+	context("UnmarshalJSON", func() {
+		it("correctly unmarshals JSON", func() {
+
+			err := json.Unmarshal(input, &rts)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(rts)).To(Equal(2))
+			Expect(rts).To(ContainElement(internal.RuntimeTarget{
+				FileName:          "runtimes/unix/lib/netstandard2.0/Microsoft.Win32.Registry.dll",
+				AssetType:         "runtime",
+				RuntimeIdentifier: "unix",
+			}))
+			Expect(rts).To(ContainElement(internal.RuntimeTarget{
+				FileName:          "runtimes/win/lib/netstandard2.0/Microsoft.Win32.Registry.dll",
+				AssetType:         "runtime",
+				RuntimeIdentifier: "win",
+			}))
+		})
+
+		context("failure cases", func() {
+			context("when a target has an invalid dependency list structure", func() {
+				it("returns an error", func() {
+
+					err := json.Unmarshal(badInput, &rts)
+					Expect(err).To(MatchError(ContainSubstring("cannot unmarshal bool into Go value of type map[string]interface {}")), err.Error())
+				})
+			})
+		})
+	})
+}
+
+func testRuntime(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect  = NewWithT(t).Expect
+		runtime internal.Runtime
+	)
+	var input []byte = []byte(`{
+          "lib/netstandard1.3/Consul.dll": {}
+        }`)
+	var badInput []byte = []byte(`[ "not-a-map" ]`)
+
+	context("UnmarshalJSON", func() {
+		it("correctly unmarshals JSON", func() {
+
+			err := json.Unmarshal(input, &runtime)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(runtime).To(Equal(internal.Runtime("lib/netstandard1.3/Consul.dll")))
+		})
+
+		context("failure cases", func() {
+			context("when a target has an invalid dependency list structure", func() {
+				it("returns an error", func() {
+
+					err := json.Unmarshal(badInput, &runtime)
+					Expect(err).To(MatchError(ContainSubstring("cannot unmarshal array into Go value of type map[string]interface {}")))
+				})
+			})
+		})
+	})
+}

--- a/output_slicer.go
+++ b/output_slicer.go
@@ -63,7 +63,6 @@ func (s OutputSlicer) Slice(assetsFile string) (pkgs, earlyPkgs, projects packit
 				slices = addPath(slices, dep.Type, filepath.Base(rt.FileName))
 			}
 		}
-		// TODO: What if same dependency gets filed under two different types?
 	}
 
 	for name, paths := range slices {

--- a/output_slicer.go
+++ b/output_slicer.go
@@ -1,0 +1,85 @@
+package dotnetpublish
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/paketo-buildpacks/dotnet-publish/internal"
+	"github.com/paketo-buildpacks/packit/v2"
+)
+
+type namedSlices map[string]map[string]string
+
+func addPath(slices namedSlices, name, element string) namedSlices {
+	if _, ok := slices[name]; !ok {
+		slices[name] = map[string]string{}
+	}
+	slices[name][element] = ""
+	return slices
+}
+
+type OutputSlicer struct{}
+
+func NewOutputSlicer() OutputSlicer {
+	return OutputSlicer{}
+}
+
+func (s OutputSlicer) Slice(assetsFile string) (pkgs, earlyPkgs, projects packit.Slice, err error) {
+	contents, err := os.Open(assetsFile)
+	if err != nil {
+		return packit.Slice{}, packit.Slice{}, packit.Slice{}, fmt.Errorf("opening assets file to identify output slices: %w", err)
+	}
+	defer contents.Close()
+
+	var assets internal.ProjectAssetsJSON
+	dec := json.NewDecoder(contents)
+	err = dec.Decode(&assets)
+	if err != nil {
+		return packit.Slice{}, packit.Slice{}, packit.Slice{}, fmt.Errorf("decoding JSON to identify output slices: %w", err)
+	}
+
+	slices := namedSlices{}
+
+	for _, target := range assets.Targets {
+		for _, dep := range target.Dependencies {
+			if dep.Type != "package" && dep.Type != "project" {
+				continue
+			}
+			if dep.Type == "package" {
+				version := strings.Split(dep.Name, "/")[1] // back half of dep name is version
+				if strings.Contains(version, "-") {        // version with dash is a release candidate or beta
+					dep.Type = "early-package"
+				}
+			}
+			file := filepath.Base(string(dep.Runtime))
+			if file != "" && file != "_._" {
+				slices = addPath(slices, dep.Type, file)
+			}
+
+			for _, rt := range dep.RuntimeTargets {
+				slices = addPath(slices, dep.Type, filepath.Base(rt.FileName))
+			}
+		}
+		// TODO: What if same dependency gets filed under two different types?
+	}
+
+	for name, paths := range slices {
+		var slicePaths *[]string
+		switch name {
+		case "package":
+			slicePaths = &pkgs.Paths
+		case "early-package":
+			slicePaths = &earlyPkgs.Paths
+		case "project":
+			slicePaths = &projects.Paths
+		}
+
+		for path := range paths {
+			*slicePaths = append(*slicePaths, path)
+		}
+	}
+	return pkgs, earlyPkgs, projects, nil
+}

--- a/output_slicer_test.go
+++ b/output_slicer_test.go
@@ -1,0 +1,93 @@
+package dotnetpublish_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	dotnetpublish "github.com/paketo-buildpacks/dotnet-publish"
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testOutputSlicer(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		slicer    dotnetpublish.OutputSlicer
+		assetsDir string
+	)
+
+	it.Before(func() {
+		var err error
+		assetsDir, err = occam.Source("testdata")
+		Expect(err).NotTo(HaveOccurred())
+
+		slicer = dotnetpublish.NewOutputSlicer()
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(assetsDir)).To(Succeed())
+	})
+
+	it("extracts the base file name of packages' runtime and runtimeTargets", func() {
+		pkgs, _, _, err := slicer.Slice(filepath.Join(assetsDir, "packages.project.assets.json"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkgs.Paths).To(HaveLen(5))
+		// Must use ContainElements, not Equal(), because unpacking JSON map into array
+		// produces non-deterministic ordering
+		Expect(pkgs.Paths).To(ContainElements([]string{
+			"Microsoft.OpenApi.dll",
+			"Swashbuckle.AspNetCore.SwaggerGen.dll",
+			"Grpc.Core.dll",
+			"libgrpc_csharp_ext.arm64.so",
+			"grpc_csharp_ext.x86.dll",
+		}))
+		// Ignore the blanked out file name for the CSharp dependency
+		Expect(pkgs.Paths).NotTo(ContainElement("_._"))
+	})
+
+	it("extracts the base file name of projects' runtime dlls", func() {
+		pkgs, earlyPkgs, projects, err := slicer.Slice(filepath.Join(assetsDir, "projects.project.assets.json"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkgs.Paths).To(HaveLen(2))
+		Expect(earlyPkgs.Paths).To(HaveLen(0))
+		Expect(projects.Paths).To(HaveLen(2))
+		Expect(projects.Paths).To(ContainElements([]string{
+			"Migrations.dll",
+			"Squidex.Domain.Apps.Core.Model.dll",
+		}))
+	})
+
+	it("distinguishes between packages and early packages", func() {
+		pkgs, earlyPkgs, projects, err := slicer.Slice(filepath.Join(assetsDir, "packages.project.assets.json"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkgs.Paths).To(HaveLen(5))
+		Expect(earlyPkgs.Paths).To(HaveLen(1))
+		Expect(projects.Paths).To(HaveLen(0))
+	})
+
+	context("failure cases", func() {
+		context("assets file cannot be opened", func() {
+			it.Before(func() {
+				Expect(os.Chmod(filepath.Join(assetsDir, "packages.project.assets.json"), 0000)).To(Succeed())
+			})
+			it.After(func() {
+				Expect(os.Chmod(filepath.Join(assetsDir, "packages.project.assets.json"), os.ModePerm)).To(Succeed())
+			})
+			it("returns an error", func() {
+				_, _, _, err := slicer.Slice(filepath.Join(assetsDir, "packages.project.assets.json"))
+				Expect(err).To(MatchError(ContainSubstring("permission denied")))
+			})
+		})
+		context("assets file JSON cannot be decoded", func() {
+			// TODO Discuss: Should the slicer actually fail here? Or is slicing optional behaviour?
+			it("returns an error", func() {
+				_, _, _, err := slicer.Slice(filepath.Join(assetsDir, "malformed.project.assets.json"))
+				Expect(err).To(MatchError(ContainSubstring("invalid character 's' looking for beginning of value")))
+			})
+		})
+	})
+}

--- a/run/main.go
+++ b/run/main.go
@@ -38,6 +38,7 @@ func main() {
 				logger,
 				chronos.DefaultClock,
 			),
+			dotnetpublish.NewOutputSlicer(),
 			bpYMLParser,
 			configParser,
 			chronos.DefaultClock,

--- a/testdata/malformed.project.assets.json
+++ b/testdata/malformed.project.assets.json
@@ -1,0 +1,1 @@
+some-garbage-not-JSON

--- a/testdata/packages.project.assets.json
+++ b/testdata/packages.project.assets.json
@@ -1,0 +1,79 @@
+{
+  "version": 3,
+  "targets": {
+    ".NETCoreApp,Version=v3.1": {
+      "Microsoft.OpenApi/1.2.3": {
+        "type": "package",
+        "compile": {
+          "some-compile-time.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.OpenApi.dll": {}
+        }
+      },
+      "Swashbuckle.AspNetCore.Swagger/6.2.2-rc1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.OpenApi": "1.2.3"
+        },
+        "compile": {
+          "some-compile-time.dll": {}
+        },
+        "runtime": {
+          "lib/netcoreapp3.0/Swashbuckle.AspNetCore.Swagger.dll": {}
+        },
+        "frameworkReferences": [
+          "Microsoft.AspNetCore.App"
+        ]
+      },
+      "Swashbuckle.AspNetCore.SwaggerGen/6.2.2": {
+        "type": "package",
+        "dependencies": {
+          "Swashbuckle.AspNetCore.Swagger": "6.2.2"
+        },
+        "compile": {
+          "some-compile-time.dll": {}
+        },
+        "runtime": {
+          "lib/netcoreapp3.0/Swashbuckle.AspNetCore.SwaggerGen.dll": {}
+        }
+      },
+      "Grpc.Core/2.41.0": {
+        "type": "package",
+        "dependencies": {
+          "Grpc.Core.Api": "2.41.0",
+          "System.Memory": "4.5.3"
+        },
+        "compile": {
+          "lib/netstandard2.0/Grpc.Core.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard2.0/Grpc.Core.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/linux-arm64/native/libgrpc_csharp_ext.arm64.so": {
+            "assetType": "native",
+            "rid": "linux-arm64"
+          },
+          "runtimes/win-x86/native/grpc_csharp_ext.x86.dll": {
+            "assetType": "native",
+            "rid": "win-x86"
+          }
+        }
+      },
+      "Microsoft.CSharp/4.7.0": {
+        "type": "package",
+        "compile": {
+          "ref/netcoreapp2.0/_._": {}
+        },
+        "runtime": {
+          "lib/netcoreapp2.0/_._": {}
+        }
+      }
+    }
+  },
+  "libraries": {},
+  "projectFileDependencyGroups": {},
+  "packageFolders": {},
+  "project": {}
+}

--- a/testdata/projects.project.assets.json
+++ b/testdata/projects.project.assets.json
@@ -1,0 +1,67 @@
+{
+  "version": 3,
+  "targets": {
+    ".NETCoreApp,Version=v3.1": {
+      "YamlDotNet/11.2.1": {
+        "type": "package",
+        "compile": {
+          "compile-dep.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard2.1/YamlDotNet.dll": {}
+        }
+      },
+      "Migrations/1.0.0": {
+        "type": "project",
+        "framework": ".NETCoreApp,Version=v6.0",
+        "dependencies": {
+          "Squidex.Domain.Apps.Core.Model": "1.0.0",
+          "Squidex.Domain.Apps.Entities": "1.0.0",
+          "Squidex.Domain.Apps.Entities.MongoDb": "1.0.0",
+          "Squidex.Domain.Apps.Events": "1.0.0",
+          "Squidex.Infrastructure": "1.0.0",
+          "Squidex.Infrastructure.MongoDb": "1.0.0"
+        },
+        "compile": {
+          "compile-dep.dll": {}
+        },
+        "runtime": {
+          "bin/placeholder/Migrations.dll": {}
+        }
+      },
+      "Squidex.Domain.Apps.Core.Model/1.0.0": {
+        "type": "project",
+        "framework": ".NETCoreApp,Version=v6.0",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.UserSecrets": "6.0.0",
+          "Squidex.Infrastructure": "1.0.0",
+          "Squidex.Shared": "1.0.0",
+          "System.Collections.Immutable": "6.0.0",
+          "System.ComponentModel.Annotations": "5.0.0"
+        },
+        "compile": {
+          "bin/placeholder/Squidex.Domain.Apps.Core.Model.dll": {}
+        },
+        "runtime": {
+          "bin/placeholder/Squidex.Domain.Apps.Core.Model.dll": {}
+        }
+      },
+      "Swashbuckle.AspNetCore.SwaggerGen/6.2.2": {
+        "type": "package",
+        "dependencies": {
+          "Swashbuckle.AspNetCore.Swagger": "6.2.2"
+        },
+        "compile": {
+          "some-compile-time.dll": {}
+        },
+        "runtime": {
+          "lib/netcoreapp3.0/Swashbuckle.AspNetCore.SwaggerGen.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {},
+  "projectFileDependencyGroups": {},
+  "packageFolders": {},
+  "project": {}
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Resolves https://github.com/paketo-buildpacks/dotnet-core/issues/610

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
