### PR TITLE
Fix project.assets.json unmarshaller

### DIFF
--- a/internal/init_test.go
+++ b/internal/init_test.go
@@ -11,7 +11,7 @@ func TestUnitInternal(t *testing.T) {
 	suite := spec.New("internal", spec.Report(report.Terminal{}))
 	suite("Targets", testTargets)
 	suite("RuntimeTargets", testRuntimeTargets)
-	suite("Runtime", testRuntime)
+	suite("RuntimeDependencies", testRuntimeDependencies)
 	suite("Dependencies", testDependencies)
 	suite.Run(t)
 }

--- a/internal/project_assets_json.go
+++ b/internal/project_assets_json.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 type ProjectAssetsJSON struct {
@@ -19,13 +18,13 @@ type Target struct {
 type Dependencies []ProjectDependency
 
 type ProjectDependency struct {
-	Name           string
-	Type           string         `json:"type"`
-	Runtime        Runtime        `json:"runtime"`
-	RuntimeTargets RuntimeTargets `json:"runtimeTargets"`
+	Name                string
+	Type                string              `json:"type"`
+	RuntimeDependencies RuntimeDependencies `json:"runtime"`
+	RuntimeTargets      RuntimeTargets      `json:"runtimeTargets"`
 }
 
-type Runtime string
+type RuntimeDependencies []string
 
 type RuntimeTargets []RuntimeTarget
 
@@ -65,18 +64,19 @@ func (ds *Dependencies) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (r *Runtime) UnmarshalJSON(data []byte) error {
-
-	var v map[string]interface{}
+func (rs *RuntimeDependencies) UnmarshalJSON(data []byte) error {
+	var (
+		result []string
+		v      map[string]interface{}
+	)
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
-	if len(v) != 1 {
-		return fmt.Errorf("dependency runtime file malformed")
-	}
+
 	for key := range v {
-		*r = Runtime(key)
+		result = append(result, key)
 	}
+	*rs = RuntimeDependencies(result)
 	return nil
 }
 

--- a/internal/project_assets_json_test.go
+++ b/internal/project_assets_json_test.go
@@ -94,9 +94,9 @@ func testTargets(t *testing.T, context spec.G, it spec.S) {
 				Name: ".NETCoreApp,Version=v3.1",
 				Dependencies: internal.Dependencies([]internal.ProjectDependency{
 					{
-						Name:    "Microsoft.AspNetCore.Diagnostics.HealthChecks/2.2.0-rc1",
-						Type:    "package",
-						Runtime: "lib/netstandard2.0/Microsoft.AspNetCore.Diagnostics.HealthChecks.dll",
+						Name:                "Microsoft.AspNetCore.Diagnostics.HealthChecks/2.2.0-rc1",
+						Type:                "package",
+						RuntimeDependencies: []string{"lib/netstandard2.0/Microsoft.AspNetCore.Diagnostics.HealthChecks.dll"},
 					},
 				}),
 			}))
@@ -104,9 +104,9 @@ func testTargets(t *testing.T, context spec.G, it spec.S) {
 				Name: ".NETCoreApp,Version=v6.0",
 				Dependencies: internal.Dependencies([]internal.ProjectDependency{
 					{
-						Name:    "Consul/0.7.2.6",
-						Type:    "package",
-						Runtime: "lib/netstandard1.3/Consul.dll",
+						Name:                "Consul/0.7.2.6",
+						Type:                "package",
+						RuntimeDependencies: []string{"lib/netstandard1.3/Consul.dll"},
 					},
 				}),
 			}))
@@ -186,14 +186,14 @@ func testDependencies(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(len(deps)).To(Equal(2))
 			Expect(deps).To(ContainElement(internal.ProjectDependency{
-				Name:    "Consul/0.7.2.6",
-				Type:    "package",
-				Runtime: "lib/netstandard1.3/Consul.dll",
+				Name:                "Consul/0.7.2.6",
+				Type:                "package",
+				RuntimeDependencies: []string{"lib/netstandard1.3/Consul.dll"},
 			}))
 			Expect(deps).To(ContainElement(internal.ProjectDependency{
-				Name:    "Microsoft.Win32.Registry/4.6.0",
-				Type:    "package",
-				Runtime: "lib/netstandard2.0/Microsoft.Win32.Registry.dll",
+				Name:                "Microsoft.Win32.Registry/4.6.0",
+				Type:                "package",
+				RuntimeDependencies: []string{"lib/netstandard2.0/Microsoft.Win32.Registry.dll"},
 				RuntimeTargets: internal.RuntimeTargets([]internal.RuntimeTarget{
 					{
 						FileName:          "runtimes/unix/lib/netstandard2.0/Microsoft.Win32.Registry.dll",
@@ -270,13 +270,14 @@ func testRuntimeTargets(t *testing.T, context spec.G, it spec.S) {
 	})
 }
 
-func testRuntime(t *testing.T, context spec.G, it spec.S) {
+func testRuntimeDependencies(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect  = NewWithT(t).Expect
-		runtime internal.Runtime
+		runtime internal.RuntimeDependencies
 	)
 	var input []byte = []byte(`{
-          "lib/netstandard1.3/Consul.dll": {}
+          "lib/netstandard1.3/Consul.dll": {},
+          "lib/netstandard2.0/Microsoft.Diagnostics.FastSerialization.dll": {}
         }`)
 	var badInput []byte = []byte(`[ "not-a-map" ]`)
 
@@ -286,7 +287,10 @@ func testRuntime(t *testing.T, context spec.G, it spec.S) {
 			err := json.Unmarshal(input, &runtime)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(runtime).To(Equal(internal.Runtime("lib/netstandard1.3/Consul.dll")))
+			Expect(runtime).To(Equal(internal.RuntimeDependencies([]string{
+				"lib/netstandard1.3/Consul.dll",
+				"lib/netstandard2.0/Microsoft.Diagnostics.FastSerialization.dll",
+			})))
 		})
 
 		context("failure cases", func() {

--- a/output_slicer.go
+++ b/output_slicer.go
@@ -54,9 +54,11 @@ func (s OutputSlicer) Slice(assetsFile string) (pkgs, earlyPkgs, projects packit
 					dep.Type = "early-package"
 				}
 			}
-			file := filepath.Base(string(dep.Runtime))
-			if file != "" && file != "_._" {
-				slices = addPath(slices, dep.Type, file)
+			for _, runtime := range dep.RuntimeDependencies {
+				file := filepath.Base(string(runtime))
+				if file != "" && file != "_._" {
+					slices = addPath(slices, dep.Type, file)
+				}
 			}
 
 			for _, rt := range dep.RuntimeTargets {

--- a/output_slicer_test.go
+++ b/output_slicer_test.go
@@ -35,7 +35,7 @@ func testOutputSlicer(t *testing.T, context spec.G, it spec.S) {
 	it("extracts the base file name of packages' runtime and runtimeTargets", func() {
 		pkgs, _, _, err := slicer.Slice(filepath.Join(assetsDir, "packages.project.assets.json"))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(pkgs.Paths).To(HaveLen(5))
+		Expect(pkgs.Paths).To(HaveLen(10))
 		// Must use ContainElements, not Equal(), because unpacking JSON map into array
 		// produces non-deterministic ordering
 		Expect(pkgs.Paths).To(ContainElements([]string{
@@ -44,6 +44,11 @@ func testOutputSlicer(t *testing.T, context spec.G, it spec.S) {
 			"Grpc.Core.dll",
 			"libgrpc_csharp_ext.arm64.so",
 			"grpc_csharp_ext.x86.dll",
+			"Dia2Lib.dll",
+			"Microsoft.Diagnostics.FastSerialization.dll",
+			"Microsoft.Diagnostics.Tracing.TraceEvent.dll",
+			"OSExtensions.dll",
+			"TraceReloggerLib.dll",
 		}))
 		// Ignore the blanked out file name for the CSharp dependency
 		Expect(pkgs.Paths).NotTo(ContainElement("_._"))
@@ -64,7 +69,7 @@ func testOutputSlicer(t *testing.T, context spec.G, it spec.S) {
 	it("distinguishes between packages and early packages", func() {
 		pkgs, earlyPkgs, projects, err := slicer.Slice(filepath.Join(assetsDir, "packages.project.assets.json"))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(pkgs.Paths).To(HaveLen(5))
+		Expect(pkgs.Paths).To(HaveLen(10))
 		Expect(earlyPkgs.Paths).To(HaveLen(1))
 		Expect(projects.Paths).To(HaveLen(0))
 	})

--- a/testdata/packages.project.assets.json
+++ b/testdata/packages.project.assets.json
@@ -61,6 +61,29 @@
           }
         }
       },
+      "Microsoft.Diagnostics.Tracing.TraceEvent/2.0.64": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
+        },
+        "compile": {
+          "lib/netstandard2.0/Dia2Lib.dll": {},
+          "lib/netstandard2.0/Microsoft.Diagnostics.FastSerialization.dll": {},
+          "lib/netstandard2.0/Microsoft.Diagnostics.Tracing.TraceEvent.dll": {},
+          "lib/netstandard2.0/OSExtensions.dll": {},
+          "lib/netstandard2.0/TraceReloggerLib.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard2.0/Dia2Lib.dll": {},
+          "lib/netstandard2.0/Microsoft.Diagnostics.FastSerialization.dll": {},
+          "lib/netstandard2.0/Microsoft.Diagnostics.Tracing.TraceEvent.dll": {},
+          "lib/netstandard2.0/OSExtensions.dll": {},
+          "lib/netstandard2.0/TraceReloggerLib.dll": {}
+        },
+        "build": {
+          "buildTransitive/Microsoft.Diagnostics.Tracing.TraceEvent.props": {}
+        }
+      },
       "Microsoft.CSharp/4.7.0": {
         "type": "package",
         "compile": {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Resolves #320

## Use Cases
<!-- An explanation of the use cases your change enables -->
It turns out that the app mentioned in #320 includes a dependency, `Microsoft.Diagnostics.Tracing.TraceEvent/2.0.64`, that has multiple values under the `"runtime"` key. This update allows the JSON unmarshaller and output slicer to process dependencies like this. I've added the dependency that broke the previous implementation to our `testdata` for the output slicer. 

Unfortunately, I can't find a schema published anywhere for the `project.assets.json` file. We're vulnerable to bugs like this in the future.


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
