### PR TITLE
Don't rely on UID being the same in run/build

### DIFF
--- a/integration/source_removal_test.go
+++ b/integration/source_removal_test.go
@@ -92,8 +92,8 @@ func testSourceRemoval(t *testing.T, context spec.G, it spec.S) {
 				return cLogs.String()
 			}).Should(
 				And(
-					MatchRegexp(`-rw-r--r-- +\d+ +cnb +cnb.*\.runtimeconfig.json`),
-					Not(MatchRegexp(`-rw-r--r-- +\d+ +cnb +cnb.*Program.cs`)),
+					MatchRegexp(`-rw-r--r-- +\d+ +\w+ +cnb.*\.runtimeconfig.json`),
+					Not(MatchRegexp(`-rw-r--r-- +\d+ +\w+ +cnb.*Program.cs`)),
 				),
 			)
 		})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
We should be a bit more flexible in the assertions we include in the integration tests. I wasn't able to get the tests to pass when I had a run image that had a different UID than the build image. This can be resolved by just relaxing the regular expressions we use to allow the UIDs to differ.

## Use Cases
<!-- An explanation of the use cases your change enables -->
This will help the move onto the Jammy stacks.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
