### PR TITLE
Support wildcard stack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -17,7 +17,5 @@ api = "0.6"
   pre-package = "./scripts/build.sh"
 
 [[stacks]]
-  id = "org.cloudfoundry.stacks.cflinuxfs3"
+  id = "*"
 
-[[stacks]]
-  id = "io.buildpacks.stacks.bionic"

--- a/integration.json
+++ b/integration.json
@@ -1,4 +1,5 @@
 {
+  "builders": ["paketobuildpacks/builder:buildpackless-base", "paketobuildpacks/builder-jammy-buildpackless-base"],
   "dotnet-core-aspnet": "github.com/paketo-buildpacks/dotnet-core-aspnet",
   "dotnet-execute": "github.com/paketo-buildpacks/dotnet-execute",
   "dotnet-core-runtime": "github.com/paketo-buildpacks/dotnet-core-runtime",

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -37,12 +37,13 @@ var (
 		}
 	}
 	config struct {
-		NodeEngine        string `json:"node-engine"`
-		ICU               string `json:"icu"`
-		DotnetCoreRuntime string `json:"dotnet-core-runtime"`
-		DotnetCoreAspNet  string `json:"dotnet-core-aspnet"`
-		DotnetCoreSDK     string `json:"dotnet-core-sdk"`
-		DotnetExecute     string `json:"dotnet-execute"`
+		NodeEngine        string   `json:"node-engine"`
+		ICU               string   `json:"icu"`
+		DotnetCoreRuntime string   `json:"dotnet-core-runtime"`
+		DotnetCoreAspNet  string   `json:"dotnet-core-aspnet"`
+		DotnetCoreSDK     string   `json:"dotnet-core-sdk"`
+		DotnetExecute     string   `json:"dotnet-execute"`
+		Builders          []string `json:"builders"`
 	}
 )
 

--- a/integration/visual_basic_test.go
+++ b/integration/visual_basic_test.go
@@ -47,46 +47,52 @@ func testVisualBasic(t *testing.T, context spec.G, it spec.S) {
 			Expect(os.RemoveAll(source)).To(Succeed())
 		})
 
-		it("should build a working OCI image", func() {
-			var err error
-			source, err = occam.Source(filepath.Join("testdata", "visual_basic_app"))
-			Expect(err).NotTo(HaveOccurred())
+		for _, b := range config.Builders {
+			var builder string = b
+			context(fmt.Sprintf("with %s builder", builder), func() {
+				it("should build a working OCI image", func() {
+					var err error
+					source, err = occam.Source(filepath.Join("testdata", "visual_basic_app"))
+					Expect(err).NotTo(HaveOccurred())
 
-			var logs fmt.Stringer
-			image, logs, err = pack.WithNoColor().WithVerbose().Build.
-				WithBuildpacks(
-					icuBuildpack,
-					dotnetCoreRuntimeBuildpack,
-					dotnetCoreSDKBuildpack,
-					buildpack,
-					dotnetExecuteBuildpack,
-				).
-				Execute(name, source)
-			Expect(err).NotTo(HaveOccurred(), logs.String())
+					var logs fmt.Stringer
+					image, logs, err = pack.WithNoColor().WithVerbose().Build.
+						WithBuildpacks(
+							icuBuildpack,
+							dotnetCoreRuntimeBuildpack,
+							dotnetCoreSDKBuildpack,
+							buildpack,
+							dotnetExecuteBuildpack,
+						).
+						WithBuilder(builder).
+						Execute(name, source)
+					Expect(err).NotTo(HaveOccurred(), logs.String())
 
-			Expect(logs).To(ContainLines(
-				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
-				"  Executing build process",
-				MatchRegexp(`    Running 'dotnet publish \/workspace --configuration Release --runtime ubuntu\.18\.04-x64 --self-contained false --output \/tmp\/dotnet-publish-output\d+'`),
-			))
-			Expect(logs).To(ContainLines(
-				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
-				"",
-				"  Dividing build output into layers to optimize cache reuse",
-				"",
-				"  Removing source code",
-				"",
-			))
+					Expect(logs).To(ContainLines(
+						MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
+						"  Executing build process",
+						MatchRegexp(`    Running 'dotnet publish \/workspace --configuration Release --runtime ubuntu\.18\.04-x64 --self-contained false --output \/tmp\/dotnet-publish-output\d+'`),
+					))
+					Expect(logs).To(ContainLines(
+						MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),
+						"",
+						"  Dividing build output into layers to optimize cache reuse",
+						"",
+						"  Removing source code",
+						"",
+					))
 
-			container, err = docker.Container.Run.
-				Execute(image.ID)
-			Expect(err).NotTo(HaveOccurred())
+					container, err = docker.Container.Run.
+						Execute(image.ID)
+					Expect(err).NotTo(HaveOccurred())
 
-			Eventually(func() string {
-				cLogs, err := docker.Container.Logs.Execute(container.ID)
-				Expect(err).NotTo(HaveOccurred())
-				return cLogs.String()
-			}).Should(ContainSubstring("Hello World!"))
-		})
+					Eventually(func() string {
+						cLogs, err := docker.Container.Logs.Execute(container.ID)
+						Expect(err).NotTo(HaveOccurred())
+						return cLogs.String()
+					}).Should(ContainSubstring("Hello World!"))
+				})
+			})
+		}
 	})
 }

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -77,38 +77,46 @@ function tools::install() {
 }
 
 function images::pull() {
-  local builder
-  builder=""
+  local builders
+  builders=""
 
   if [[ -f "${BUILDPACKDIR}/integration.json" ]]; then
-    builder="$(jq -r .builder "${BUILDPACKDIR}/integration.json")"
+    builders="$(jq -r .builder "${BUILDPACKDIR}/integration.json")"
   fi
 
-  if [[ "${builder}" == "null" || -z "${builder}" ]]; then
-    builder="index.docker.io/paketobuildpacks/builder:buildpackless-base"
+  if [[ "${builders}" == "null" || -z "${builders}" ]]; then
+    builders="$(jq -r 'select(.builders != null) | .builders[]' "${BUILDPACKDIR}/integration.json")"
   fi
 
-  util::print::title "Pulling builder image..."
-  docker pull "${builder}"
+  if [[ "${builders}" == "null" || -z "${builders}" ]]; then
+    builders="index.docker.io/paketobuildpacks/builder:buildpackless-base"
+  fi
 
-  util::print::title "Setting default pack builder image..."
-  pack config default-builder "${builder}"
+  while read -r builder; do
+    util::print::title "Pulling builder image ${builder}..."
+    docker pull "${builder}"
 
-  local run_image lifecycle_image
-  run_image="$(
-    pack inspect-builder "${builder}" --output json \
-      | jq -r '.remote_info.run_images[0].name'
-  )"
-  lifecycle_image="index.docker.io/buildpacksio/lifecycle:$(
-    pack inspect-builder "${builder}" --output json \
-      | jq -r '.remote_info.lifecycle.version'
-  )"
+    local run_image lifecycle_image
+    run_image="$(
+      pack inspect-builder "${builder}" --output json \
+        | jq -r '.remote_info.run_images[0].name'
+    )"
+    lifecycle_image="index.docker.io/buildpacksio/lifecycle:$(
+      pack inspect-builder "${builder}" --output json \
+        | jq -r '.remote_info.lifecycle.version'
+    )"
 
-  util::print::title "Pulling run image..."
-  docker pull "${run_image}"
+    util::print::title "Pulling run image..."
+    docker pull "${run_image}"
 
-  util::print::title "Pulling lifecycle image..."
-  docker pull "${lifecycle_image}"
+    util::print::title "Pulling lifecycle image..."
+    docker pull "${lifecycle_image}"
+  done <<< "${builders}"
+
+    util::print::title "Setting default pack builder image..."
+    local default
+    read -r default <<< "${builders}"
+    pack config default-builder "${default}"
 }
 
 function token::fetch() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Since this buildpack does not install any dependencies, I've set this to support the wildcard stack. Theoretically, any stack where the dotnet toolchain has been installed should be compatible with this buildpack.

I've added tests against the bionic and jammy builders. This requires a slight change to our integration script. See https://github.com/paketo-buildpacks/github-config/pull/497

## Use Cases
<!-- An explanation of the use cases your change enables -->
This facilitates us running the .NET Core buildpack on Jammy Jellyfish and other stacks in the future.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
