### PR TITLE
Use vsdbg buildpack in integration tests

### DIFF
--- a/integration.json
+++ b/integration.json
@@ -5,5 +5,6 @@
   "dotnet-core-runtime": "github.com/paketo-buildpacks/dotnet-core-runtime",
   "dotnet-core-sdk": "github.com/paketo-buildpacks/dotnet-core-sdk",
   "icu": "github.com/paketo-buildpacks/icu",
+  "vsdbg": "github.com/paketo-buildpacks/vsdbg",
   "node-engine": "github.com/paketo-buildpacks/node-engine"
 }

--- a/integration/default_apps_test.go
+++ b/integration/default_apps_test.go
@@ -73,6 +73,7 @@ func testDefaultApps(t *testing.T, context spec.G, it spec.S) {
 							dotnetCoreRuntimeBuildpack,
 							dotnetCoreAspNetBuildpack,
 							dotnetCoreSDKBuildpack,
+							vsdbgBuildpack,
 							buildpack,
 							dotnetExecuteBuildpack,
 						).

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -31,6 +31,7 @@ var (
 	dotnetCoreSDKBuildpack            string
 	dotnetCoreSDKOfflineBuildpack     string
 	dotnetExecuteBuildpack            string
+	vsdbgBuildpack                    string
 	buildpack                         string
 	offlineBuildpack                  string
 	builder                           struct {
@@ -53,6 +54,7 @@ var (
 		DotnetCoreAspNet  string `json:"dotnet-core-aspnet"`
 		DotnetCoreSDK     string `json:"dotnet-core-sdk"`
 		DotnetExecute     string `json:"dotnet-execute"`
+		Vsdbg             string `json:"vsdbg"`
 	}
 )
 
@@ -140,6 +142,10 @@ func TestIntegration(t *testing.T) {
 
 	dotnetExecuteBuildpack, err = buildpackStore.Get.
 		Execute(config.DotnetExecute)
+	Expect(err).NotTo(HaveOccurred())
+
+	vsdbgBuildpack, err = buildpackStore.Get.
+		Execute(config.Vsdbg)
 	Expect(err).NotTo(HaveOccurred())
 
 	SetDefaultEventuallyTimeout(30 * time.Second)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
As of [v0.11.0](https://github.com/paketo-buildpacks/dotnet-execute/releases/tag/v0.11.0) the dotnet-execute buildpack requires `vsdbg` when `BP_DEBUG_ENABLED=true` in the build environment. The integration tests for this buildpack must include the vsdbg buildpack for builds with `BP_DEBUG_ENABLED=true`.
## Use Cases
<!-- An explanation of the use cases your change enables -->
 This will address integration test failures like [this one](https://github.com/paketo-buildpacks/dotnet-publish/runs/7882940856?check_suite_focus=true#step:5:486).


## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
