### PR TITLE
Require ICU 70.* when using .NET 3.1

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -3,6 +3,7 @@ package dotnetpublish
 import (
 	"fmt"
 	"path/filepath"
+	"regexp"
 
 	"github.com/Masterminds/semver"
 	"github.com/paketo-buildpacks/packit/v2"
@@ -66,13 +67,30 @@ func Detect(config Configuration, parser ProjectParser, buildpackYMLParser Build
 					VersionSource: filepath.Base(projectFilePath),
 				},
 			},
-			{
-				Name: "icu",
-				Metadata: BuildPlanMetadata{
-					Build: true,
-				},
-			},
 		}
+
+		// Determine ICU metadata to include
+		// If .NET Core is 3.1 version line, require ICU 70.*
+		// See https://forum.manjaro.org/t/dotnet-3-1-builds-fail-after-icu-system-package-updated-to-71-1-1/114232/9 for details
+		icuBuildPlanMetadata := BuildPlanMetadata{
+			Build: true,
+		}
+
+		isDotnet31, err := checkDotnet31(version)
+		if err != nil {
+			// untested, version will have already failed on line 56 if
+			// malformed
+			return packit.DetectResult{}, err
+		}
+		if isDotnet31 {
+			icuBuildPlanMetadata.Version = "70.*"
+			icuBuildPlanMetadata.VersionSource = "dotnet-31"
+		}
+
+		requirements = append(requirements, packit.BuildPlanRequirement{
+			Name:     "icu",
+			Metadata: icuBuildPlanMetadata,
+		})
 
 		nodeReq, err := parser.NodeIsRequired(projectFilePath)
 		if err != nil {
@@ -111,4 +129,14 @@ func Detect(config Configuration, parser ProjectParser, buildpackYMLParser Build
 			},
 		}, nil
 	}
+}
+
+func checkDotnet31(version string) (bool, error) {
+	match, err := regexp.MatchString(`3\.1\.*`, version)
+	if err != nil {
+		// untested because regexp pattern is hardcoded
+		return false, err
+	}
+
+	return match, nil
 }

--- a/detect_test.go
+++ b/detect_test.go
@@ -32,7 +32,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 		projectParser = &fakes.ProjectParser{}
 		projectParser.FindProjectFileCall.Returns.String = filepath.Join(workingDir, "app.csproj")
-		projectParser.ParseVersionCall.Returns.String = "3.1.0"
+		projectParser.ParseVersionCall.Returns.String = "6.0.0"
 
 		buildpackYMLParser = &fakes.BuildpackYMLParser{}
 
@@ -61,7 +61,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					{
 						Name: "dotnet-sdk",
 						Metadata: dotnetpublish.BuildPlanMetadata{
-							Version:       "3.1.*",
+							Version:       "6.0.*",
 							VersionSource: "app.csproj",
 							Build:         true,
 						},
@@ -83,6 +83,50 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		Expect(projectParser.NPMIsRequiredCall.Receives.Path).To(Equal(filepath.Join(workingDir, "app.csproj")))
 	})
 
+	context("when .NET Core 3.1 is required by the project file", func() {
+		it.Before(func() {
+			projectParser.ParseVersionCall.Returns.String = "3.1.0"
+		})
+
+		it("requires ICU 70.* in the build plan", func() {
+			result, err := detect(packit.DetectContext{
+				WorkingDir: workingDir,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(packit.DetectResult{
+				Plan: packit.BuildPlan{
+					Provides: []packit.BuildPlanProvision{
+						{Name: "dotnet-application"},
+					},
+					Requires: []packit.BuildPlanRequirement{
+						{
+							Name: "dotnet-sdk",
+							Metadata: dotnetpublish.BuildPlanMetadata{
+								Version:       "3.1.*",
+								VersionSource: "app.csproj",
+								Build:         true,
+							},
+						},
+						{
+							Name: "icu",
+							Metadata: dotnetpublish.BuildPlanMetadata{
+								Build:         true,
+								Version:       "70.*",
+								VersionSource: "dotnet-31",
+							},
+						},
+					},
+				},
+			}))
+
+			Expect(buildpackYMLParser.ParseProjectPathCall.Receives.Path).To(Equal(filepath.Join(workingDir, "buildpack.yml")))
+			Expect(projectParser.FindProjectFileCall.Receives.Root).To(Equal(workingDir))
+			Expect(projectParser.ParseVersionCall.Receives.Path).To(Equal(filepath.Join(workingDir, "app.csproj")))
+			Expect(projectParser.NodeIsRequiredCall.Receives.Path).To(Equal(filepath.Join(workingDir, "app.csproj")))
+			Expect(projectParser.NPMIsRequiredCall.Receives.Path).To(Equal(filepath.Join(workingDir, "app.csproj")))
+		})
+
+	})
 	context("when node is required", func() {
 		it.Before(func() {
 			projectParser.NodeIsRequiredCall.Returns.Bool = true
@@ -102,7 +146,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						{
 							Name: "dotnet-sdk",
 							Metadata: dotnetpublish.BuildPlanMetadata{
-								Version:       "3.1.*",
+								Version:       "6.0.*",
 								VersionSource: "app.csproj",
 								Build:         true,
 							},
@@ -151,7 +195,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						{
 							Name: "dotnet-sdk",
 							Metadata: dotnetpublish.BuildPlanMetadata{
-								Version:       "3.1.*",
+								Version:       "6.0.*",
 								VersionSource: "app.csproj",
 								Build:         true,
 							},
@@ -214,7 +258,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						{
 							Name: "dotnet-sdk",
 							Metadata: dotnetpublish.BuildPlanMetadata{
-								Version:       "3.1.*",
+								Version:       "6.0.*",
 								VersionSource: "app.csproj",
 								Build:         true,
 							},
@@ -260,7 +304,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						{
 							Name: "dotnet-sdk",
 							Metadata: dotnetpublish.BuildPlanMetadata{
-								Version:       "3.1.*",
+								Version:       "6.0.*",
 								VersionSource: "app.csproj",
 								Build:         true,
 							},


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Part of https://github.com/paketo-buildpacks/dotnet-core/issues/771
When .NET Core 3.1 is requested, request ICU version `70.*`. 

Changes to ICU to allow version selection and make sure there is always a `70.*` version line will be added in a separate PR. Until that PR is merged and released, this PR will have no effect on the version selected of ICU since ICU does not currently have any version selection logic.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
