### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,7 +5,7 @@ api = "0.8"
   homepage = "https://github.com/paketo-buildpacks/dotnet-publish"
   id = "paketo-buildpacks/dotnet-publish"
   keywords = ["dotnet"]
-  name = "Paketo .NET Publish Buildpack"
+  name = "Paketo Buildpack for .NET Publish"
   version = "{{ .Version }}"
 
   [[buildpack.licenses]]


### PR DESCRIPTION
Renames 'Paketo .NET Publish Buildpack' to 'Paketo Buildpack for .NET Publish'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
