### PR TITLE
Makes --runtime flag more general

### DIFF
--- a/dotnet_publish_process.go
+++ b/dotnet_publish_process.go
@@ -44,7 +44,7 @@ func (p DotnetPublishProcess) Execute(workingDir, nugetCachePath, projectPath, o
 	}
 
 	if !containsFlag(flags, "--runtime") && !containsFlag(flags, "-r") {
-		args = append(args, "--runtime", "ubuntu.18.04-x64")
+		args = append(args, "--runtime", "linux-x64")
 	}
 
 	if !containsFlag(flags, "--self-contained") && !containsFlag(flags, "--no-self-contained") {

--- a/dotnet_publish_process.go
+++ b/dotnet_publish_process.go
@@ -43,6 +43,10 @@ func (p DotnetPublishProcess) Execute(workingDir, nugetCachePath, projectPath, o
 		}
 	}
 
+	if !containsFlag(flags, "--runtime") && !containsFlag(flags, "-r") {
+		args = append(args, "--runtime", "ubuntu.18.04-x64")
+	}
+
 	if !containsFlag(flags, "--self-contained") && !containsFlag(flags, "--no-self-contained") {
 		args = append(args, "--self-contained", "false")
 	}

--- a/dotnet_publish_process_test.go
+++ b/dotnet_publish_process_test.go
@@ -74,6 +74,7 @@ func testDotnetPublishProcess(t *testing.T, context spec.G, it spec.S) {
 		args := []string{
 			"publish", "some-working-dir/some/project/path",
 			"--configuration", "Release",
+			"--runtime", "ubuntu.18.04-x64",
 			"--self-contained", "false",
 			"--output", "some-publish-output-dir",
 			"--flag", "value",
@@ -99,6 +100,7 @@ func testDotnetPublishProcess(t *testing.T, context spec.G, it spec.S) {
 			args := []string{
 				"publish", "some-working-dir/some/project/path",
 				"--configuration", "Debug",
+				"--runtime", "ubuntu.18.04-x64",
 				"--self-contained", "false",
 				"--output", "some-publish-output-dir",
 				"--flag", "value",
@@ -122,7 +124,7 @@ func testDotnetPublishProcess(t *testing.T, context spec.G, it spec.S) {
 		it("overrides the default value with the user-provided one", func() {
 			err := process.Execute("some-working-dir", "some/nuget/cache/path", "some/project/path", "some-publish-output-dir",
 				true,
-				[]string{
+				[]string{"--runtime", "user-value",
 					"--self-contained=true",
 					"--configuration", "UserConfiguration",
 					"--output", "some-user-output-dir",
@@ -131,6 +133,7 @@ func testDotnetPublishProcess(t *testing.T, context spec.G, it spec.S) {
 
 			args := []string{
 				"publish", "some-working-dir/some/project/path",
+				"--runtime", "user-value",
 				"--self-contained=true",
 				"--configuration", "UserConfiguration",
 				"--output", "some-user-output-dir",
@@ -148,6 +151,7 @@ func testDotnetPublishProcess(t *testing.T, context spec.G, it spec.S) {
 			args := []string{
 				"publish", "some-working-dir/some/project/path",
 				"--configuration", "Release",
+				"--runtime", "ubuntu.18.04-x64",
 				"--output", "some-publish-output-dir",
 				"--no-self-contained",
 			}

--- a/dotnet_publish_process_test.go
+++ b/dotnet_publish_process_test.go
@@ -74,7 +74,7 @@ func testDotnetPublishProcess(t *testing.T, context spec.G, it spec.S) {
 		args := []string{
 			"publish", "some-working-dir/some/project/path",
 			"--configuration", "Release",
-			"--runtime", "ubuntu.18.04-x64",
+			"--runtime", "linux-x64",
 			"--self-contained", "false",
 			"--output", "some-publish-output-dir",
 			"--flag", "value",
@@ -100,7 +100,7 @@ func testDotnetPublishProcess(t *testing.T, context spec.G, it spec.S) {
 			args := []string{
 				"publish", "some-working-dir/some/project/path",
 				"--configuration", "Debug",
-				"--runtime", "ubuntu.18.04-x64",
+				"--runtime", "linux-x64",
 				"--self-contained", "false",
 				"--output", "some-publish-output-dir",
 				"--flag", "value",
@@ -151,7 +151,7 @@ func testDotnetPublishProcess(t *testing.T, context spec.G, it spec.S) {
 			args := []string{
 				"publish", "some-working-dir/some/project/path",
 				"--configuration", "Release",
-				"--runtime", "ubuntu.18.04-x64",
+				"--runtime", "linux-x64",
 				"--output", "some-publish-output-dir",
 				"--no-self-contained",
 			}

--- a/integration/match_dir_and_app_name_test.go
+++ b/integration/match_dir_and_app_name_test.go
@@ -68,7 +68,7 @@ func testMatchDirAndAppName(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
 				"  Executing build process",
-				MatchRegexp(`    Running 'dotnet publish \/workspace\/console --configuration Release --self-contained false --output \/tmp\/dotnet-publish-output\d+'`),
+				MatchRegexp(`    Running 'dotnet publish \/workspace\/console --configuration Release --runtime ubuntu\.18\.04-x64 --self-contained false --output \/tmp\/dotnet-publish-output\d+'`),
 			))
 			Expect(logs).To(ContainLines(
 				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),

--- a/integration/match_dir_and_app_name_test.go
+++ b/integration/match_dir_and_app_name_test.go
@@ -68,7 +68,7 @@ func testMatchDirAndAppName(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
 				"  Executing build process",
-				MatchRegexp(`    Running 'dotnet publish \/workspace\/console --configuration Release --runtime ubuntu\.18\.04-x64 --self-contained false --output \/tmp\/dotnet-publish-output\d+'`),
+				MatchRegexp(`    Running 'dotnet publish \/workspace\/console --configuration Release --runtime linux-x64 --self-contained false --output \/tmp\/dotnet-publish-output\d+'`),
 			))
 			Expect(logs).To(ContainLines(
 				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -68,7 +68,7 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
 				"  Executing build process",
-				MatchRegexp(`    Running 'dotnet publish \/workspace --configuration Release --runtime ubuntu\.18\.04-x64 --self-contained false --output \/tmp\/dotnet-publish-output\d+`),
+				MatchRegexp(`    Running 'dotnet publish \/workspace --configuration Release --runtime linux-x64 --self-contained false --output \/tmp\/dotnet-publish-output\d+`),
 			))
 			Expect(logs).To(ContainLines(
 				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -68,7 +68,7 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
 				"  Executing build process",
-				MatchRegexp(`    Running 'dotnet publish \/workspace --configuration Release --self-contained false --output \/tmp\/dotnet-publish-output\d+`),
+				MatchRegexp(`    Running 'dotnet publish \/workspace --configuration Release --runtime ubuntu\.18\.04-x64 --self-contained false --output \/tmp\/dotnet-publish-output\d+`),
 			))
 			Expect(logs).To(ContainLines(
 				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),

--- a/integration/source_removal_test.go
+++ b/integration/source_removal_test.go
@@ -67,7 +67,7 @@ func testSourceRemoval(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
 				"  Executing build process",
-				MatchRegexp(`    Running 'dotnet publish \/workspace --configuration Release --self-contained false --output \/tmp\/dotnet-publish-output\d+`),
+				MatchRegexp(`    Running 'dotnet publish \/workspace --configuration Release --runtime ubuntu\.18\.04-x64 --self-contained false --output \/tmp\/dotnet-publish-output\d+`),
 			))
 
 			Expect(logs).To(ContainLines(

--- a/integration/source_removal_test.go
+++ b/integration/source_removal_test.go
@@ -67,7 +67,7 @@ func testSourceRemoval(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
 				"  Executing build process",
-				MatchRegexp(`    Running 'dotnet publish \/workspace --configuration Release --runtime ubuntu\.18\.04-x64 --self-contained false --output \/tmp\/dotnet-publish-output\d+`),
+				MatchRegexp(`    Running 'dotnet publish \/workspace --configuration Release --runtime linux-x64 --self-contained false --output \/tmp\/dotnet-publish-output\d+`),
 			))
 
 			Expect(logs).To(ContainLines(

--- a/integration/visual_basic_test.go
+++ b/integration/visual_basic_test.go
@@ -67,7 +67,7 @@ func testVisualBasic(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
 				"  Executing build process",
-				MatchRegexp(`    Running 'dotnet publish \/workspace --configuration Release --self-contained false --output \/tmp\/dotnet-publish-output\d+'`),
+				MatchRegexp(`    Running 'dotnet publish \/workspace --configuration Release --runtime ubuntu\.18\.04-x64 --self-contained false --output \/tmp\/dotnet-publish-output\d+'`),
 			))
 			Expect(logs).To(ContainLines(
 				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),

--- a/integration/visual_basic_test.go
+++ b/integration/visual_basic_test.go
@@ -67,7 +67,7 @@ func testVisualBasic(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
 				"  Executing build process",
-				MatchRegexp(`    Running 'dotnet publish \/workspace --configuration Release --runtime ubuntu\.18\.04-x64 --self-contained false --output \/tmp\/dotnet-publish-output\d+'`),
+				MatchRegexp(`    Running 'dotnet publish \/workspace --configuration Release --runtime linux-x64 --self-contained false --output \/tmp\/dotnet-publish-output\d+'`),
 			))
 			Expect(logs).To(ContainLines(
 				MatchRegexp(`      Completed in ([0-9]*(\.[0-9]*)?[a-z]+)+`),


### PR DESCRIPTION
- This will prevent the import of dependencies for all platform types
  which should reduce bloat.

See https://github.com/paketo-buildpacks/dotnet-publish/pull/498#issuecomment-1637157149

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
