### PR TITLE
Add UBI builders to integration tests

### DIFF
--- a/integration.json
+++ b/integration.json
@@ -12,5 +12,6 @@
   "dotnet-core-sdk": "index.docker.io/paketobuildpacks/dotnet-core-sdk",
   "icu": "index.docker.io/paketobuildpacks/icu",
   "vsdbg": "index.docker.io/paketobuildpacks/vsdbg",
-  "node-engine": "index.docker.io/paketobuildpacks/node-engine"
+  "node-engine": "index.docker.io/paketobuildpacks/node-engine",
+  "ubi-nodejs-extension": "index.docker.io/paketobuildpacks/ubi-nodejs-extension"
 }

--- a/integration.json
+++ b/integration.json
@@ -2,7 +2,10 @@
   "builders" : [
     "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base",
     "index.docker.io/paketobuildpacks/ubuntu-noble-builder-buildpackless",
-    "index.docker.io/paketobuildpacks/ubuntu-resolute-builder-buildpackless"
+    "index.docker.io/paketobuildpacks/ubuntu-resolute-builder-buildpackless",
+    "index.docker.io/paketobuildpacks/builder-ubi8-buildpackless-base",
+    "index.docker.io/paketobuildpacks/ubi-9-builder-buildpackless",
+    "index.docker.io/paketobuildpacks/ubi-10-builder-buildpackless"
   ],
   "dotnet-core-aspnet-runtime": "index.docker.io/paketobuildpacks/dotnet-core-aspnet-runtime",
   "dotnet-execute": "index.docker.io/paketobuildpacks/dotnet-execute",

--- a/integration/default_apps_test.go
+++ b/integration/default_apps_test.go
@@ -72,7 +72,6 @@ func testDefaultApps(t *testing.T, context spec.G, it spec.S) {
 
 				var logs fmt.Stringer
 				image, logs, err = pack.WithNoColor().Build.
-					WithExtensions(ubiNodejsExtension).
 					WithBuildpacks(
 						icuBuildpack,
 						vsdbgBuildpack,
@@ -85,7 +84,6 @@ func testDefaultApps(t *testing.T, context spec.G, it spec.S) {
 						"BP_DOTNET_PUBLISH_FLAGS": "--verbosity=normal",
 						"BP_DEBUG_ENABLED":        "true",
 					}).
-					WithPullPolicy(pullPolicy).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
 				images[image.ID] = ""
@@ -299,6 +297,7 @@ func testDefaultApps(t *testing.T, context spec.G, it spec.S) {
 
 				var logs fmt.Stringer
 				image, logs, err = pack.WithNoColor().Build.
+					WithExtensions(ubiNodejsExtension).
 					WithBuildpacks(
 						nodeEngineBuildpack,
 						icuBuildpack,
@@ -307,6 +306,7 @@ func testDefaultApps(t *testing.T, context spec.G, it spec.S) {
 						dotnetCoreAspNetRuntimeBuildpack,
 						dotnetExecuteBuildpack,
 					).
+					WithPullPolicy(pullPolicy).
 					WithSBOMOutputDir(sbomDir).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())

--- a/integration/default_apps_test.go
+++ b/integration/default_apps_test.go
@@ -22,11 +22,16 @@ func testDefaultApps(t *testing.T, context spec.G, it spec.S) {
 		Eventually = NewWithT(t).Eventually
 		pack       occam.Pack
 		docker     occam.Docker
+		pullPolicy = "never"
 	)
 
 	it.Before(func() {
 		pack = occam.NewPack().WithVerbose()
 		docker = occam.NewDocker()
+
+		if ubiNodejsExtension != "" {
+			pullPolicy = "always"
+		}
 	})
 
 	context("when building a .NET Core app", func() {
@@ -67,6 +72,7 @@ func testDefaultApps(t *testing.T, context spec.G, it spec.S) {
 
 				var logs fmt.Stringer
 				image, logs, err = pack.WithNoColor().Build.
+					WithExtensions(ubiNodejsExtension).
 					WithBuildpacks(
 						icuBuildpack,
 						vsdbgBuildpack,
@@ -79,6 +85,7 @@ func testDefaultApps(t *testing.T, context spec.G, it spec.S) {
 						"BP_DOTNET_PUBLISH_FLAGS": "--verbosity=normal",
 						"BP_DEBUG_ENABLED":        "true",
 					}).
+					WithPullPolicy(pullPolicy).
 					Execute(name, source)
 				Expect(err).NotTo(HaveOccurred(), logs.String())
 				images[image.ID] = ""

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 	"time"
 
@@ -29,6 +30,7 @@ var (
 	vsdbgBuildpack                          string
 	buildpack                               string
 	offlineBuildpack                        string
+	ubiNodejsExtension                      string
 	buildpackInfo                           struct {
 		Buildpack struct {
 			ID   string
@@ -42,6 +44,7 @@ var (
 		DotnetCoreSDK           string `json:"dotnet-core-sdk"`
 		DotnetExecute           string `json:"dotnet-execute"`
 		Vsdbg                   string `json:"vsdbg"`
+		UbiNodejsExtension      string `json:"ubi-nodejs-extension"`
 	}
 )
 
@@ -76,6 +79,18 @@ func TestIntegration(t *testing.T) {
 		WithVersion("1.2.3").
 		Execute(root)
 	Expect(err).NotTo(HaveOccurred())
+
+	pack := occam.NewPack()
+
+	builder, err := pack.Builder.Inspect.Execute()
+	Expect(err).NotTo(HaveOccurred())
+
+	isUbiBuilder := regexp.MustCompile(`ubi`).MatchString(builder.BuilderName)
+
+	if isUbiBuilder {
+		Expect(occam.NewDocker().Pull.Execute(config.UbiNodejsExtension)).To(Succeed())
+		ubiNodejsExtension = config.UbiNodejsExtension
+	}
 
 	nodeEngineBuildpack, err = buildpackStore.Get.
 		Execute(config.NodeEngine)

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -85,7 +85,7 @@ func TestIntegration(t *testing.T) {
 	builder, err := pack.Builder.Inspect.Execute()
 	Expect(err).NotTo(HaveOccurred())
 
-	isUbiBuilder := regexp.MustCompile(`ubi`).MatchString(builder.BuilderName)
+	isUbiBuilder := regexp.MustCompile(`ubi8`).MatchString(builder.BuilderName)
 
 	if isUbiBuilder {
 		Expect(occam.NewDocker().Pull.Execute(config.UbiNodejsExtension)).To(Succeed())


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Add UBI builders to integration tests

This includes adding the UBI nodejs extension for UBI8 builder, otherwise this error occurs:
```
            [builder]         Determining projects to restore...
            [builder]         Restored /workspace/angular_msbuild.csproj (in 649 ms).
            [builder]         angular_msbuild -> /workspace/bin/Release/net8.0/linux-x64/angular_msbuild.dll
            [builder]         npm warn config dev Please use --include=dev instead.
            [builder]         npm error code UNABLE_TO_GET_ISSUER_CERT_LOCALLY
            [builder]         npm error errno UNABLE_TO_GET_ISSUER_CERT_LOCALLY
            [builder]         npm error request to https://registry.npmjs.org/zone.js/-/zone.js-0.11.4.tgz failed, reason: unable to get local issuer certificate
            [builder]         npm error A complete log of this run can be found in: /home/cnb/.npm/_logs/2026-08-15T04_42_51_601Z-debug-0.log
            [builder]       /workspace/angular_msbuild.csproj(36,5): error MSB3073: The command "npm --dev install" exited with code 1.
```

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
